### PR TITLE
Add GitHub Action to label new issues with NSoC

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,60 @@
+name: Label new issues with NSoC
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-gssoc-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Ensure label and add to issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+            
+            const label = "NSoC'26";
+            const color = 'C0F486'; 
+            const description = 'Under Nexus Spring of Code';
+            
+            try {
+              await github.rest.issues.updateLabel({
+                owner,
+                repo,
+                name: label,
+                new_name: label,
+                color,
+                description
+              });
+            } catch (err) {
+              if (err.status === 404) {
+                try {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: label,
+                    color,
+                    description
+                  });
+                } catch (createErr) {
+                  if (createErr.status !== 422) {
+                    throw createErr;
+                  }
+                }
+              } else {
+                throw err;
+              }
+            }
+            
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: [label]
+            });


### PR DESCRIPTION
### Description
To support NSoC 2026 triaging, every newly created issue should automatically receive the `NSoC'26` label.

### Motivation
Manual labeling can be missed and slows down filtering and assignment for contributors and maintainers.

### Proposed Solution
Add a GitHub Actions workflow triggered on `issues.opened` that:
- Ensures the `NSoC'26` label exists in the repository  
- Adds that label to the new issue automatically  

### Expected Impact
- Consistent issue labeling for NSoC 2026  
- Faster triage and better discoverability of program-related issues  
- Reduced maintainer overhead  